### PR TITLE
Frontend: Fixed clashing React dependencies

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -20,7 +20,8 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "package": "com.tempteam.frontend"
     },
     "scheme": "your-app-scheme",
     "web": {

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -5,7 +5,7 @@ export default function HomeScreen() {
   return (
     <View className="flex-1 bg-red-200">
       {/* Custom Header */}
-      <View className="flex-row items-center justify-between px-4 py-3 bg-red-400">
+      <View className="flex-row items-center justify-between px-4 py-6 bg-red-400">
         <Text className="text-xl font-bold text-blue-600">Home</Text>
         <Link href="/profile" asChild>
           <Pressable className="px-3 py-1 bg-blue-600 rounded">
@@ -16,7 +16,7 @@ export default function HomeScreen() {
       {/* Main Content */}
       <View className="flex-1 items-center justify-center">
         <Text className="text-3xl font-bold text-blue-500">
-          Welcome to the App!
+          Hot reloading?...
         </Text>
       </View>
     </View>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "expo-status-bar": "~2.2.3",
         "nativewind": "^4.1.23",
         "prettier-plugin-tailwindcss": "^0.5.14",
-        "react": "^19.0.0",
+        "react": "19.0.0",
         "react-native": "0.79.5",
         "react-native-css-interop": "^0.1.22",
         "react-native-reanimated": "~3.17.4",
@@ -2686,16 +2686,16 @@
       }
     },
     "node_modules/@react-navigation/bottom-tabs": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.4.2.tgz",
-      "integrity": "sha512-jyBux5l3qqEucY5M/ZWxVvfA8TQu7DVl2gK+xB6iKqRUfLf7dSumyVxc7HemDwGFoz3Ug8dVZFvSMEs+mfrieQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.4.4.tgz",
+      "integrity": "sha512-/YEBu/cZUgYAaNoSfUnqoRjpbt8NOsb5YvDiKVyTcOOAF1GTbUw6kRi+AGW1Sm16CqzabO/TF2RvN1RmPS9VHg==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.5.2",
+        "@react-navigation/elements": "^2.6.1",
         "color": "^4.2.3"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.14",
+        "@react-navigation/native": "^7.1.16",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -2703,12 +2703,12 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.12.1.tgz",
-      "integrity": "sha512-ir6s25CDkReufi0vQhSIAe+AAHHJN9zTgGlS6iDS1yqbwgl2MiBAZzpaOL1T5llYujie2jF/bODeLz2j4k80zw==",
+      "version": "7.12.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.12.3.tgz",
+      "integrity": "sha512-oEz5sL8KTYmCv8SQX1A4k75A7VzYadOCudp/ewOBqRXOmZdxDQA9JuN7baE9IVyaRW0QTVDy+N/Wnqx9F4aW6A==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/routers": "^7.4.1",
+        "@react-navigation/routers": "^7.5.1",
         "escape-string-regexp": "^4.0.0",
         "nanoid": "^3.3.11",
         "query-string": "^7.1.3",
@@ -2720,16 +2720,10 @@
         "react": ">= 18.2.0"
       }
     },
-    "node_modules/@react-navigation/core/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "license": "MIT"
-    },
     "node_modules/@react-navigation/elements": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.5.2.tgz",
-      "integrity": "sha512-aGC3ukF5+lXuiF5bK7bJyRuWCE+Tk4MZ3GoQpAb7u7+m0KmsquliDhj4UCWEUU5kUoCeoRAUvv+1lKcYKf+WTQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.6.1.tgz",
+      "integrity": "sha512-kVbIo+5FaqJv6MiYUR6nQHiw+10dmmH/P10C29wrH9S6fr7k69fImHGeiOI/h7SMDJ2vjWhftyEjqYO+c2LG/w==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -2738,7 +2732,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.14",
+        "@react-navigation/native": "^7.1.16",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -2750,12 +2744,12 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.14.tgz",
-      "integrity": "sha512-X233/CNx41FpshlWe4uEAUN8CNem3ju4t5pnVKcdhDR0cTQT1rK6P0ZwjSylD9zXdnHvJttFjBhKTot6TcvSqA==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.16.tgz",
+      "integrity": "sha512-JnnK81JYJ6PiMsuBEshPGHwfagRnH8W7SYdWNrPxQdNtakkHtG4u0O9FmrOnKiPl45DaftCcH1g+OVTFFgWa0Q==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/core": "^7.12.1",
+        "@react-navigation/core": "^7.12.3",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -2767,16 +2761,16 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "7.3.21",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.21.tgz",
-      "integrity": "sha512-oNNZHzkxILEibesamRKLodfXAaDOUvMBITKXLLeblDxnTAyIB/Kf7CmV+8nwkdAgV04kURTxV0SQI+d8gLUm6g==",
+      "version": "7.3.23",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.23.tgz",
+      "integrity": "sha512-WQBBnPrlM0vXj5YAFnJTyrkiCyANl2KnBV8ZmUG61HkqXFwuBbnHij6eoggXH1VZkEVRxW8k0E3qqfPtEZfUjQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.5.2",
+        "@react-navigation/elements": "^2.6.1",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.1.14",
+        "@react-navigation/native": "^7.1.16",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -2784,9 +2778,9 @@
       }
     },
     "node_modules/@react-navigation/routers": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.1.tgz",
-      "integrity": "sha512-42mZrMzQ0LfKxUb5OHIurYrPYyRsXFLolucILrvm21f0O40Sw0Ufh1bnn/jRqnxZZu7wvpUGIGYM8nS9zVE1Aw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.5.1.tgz",
+      "integrity": "sha512-pxipMW/iEBSUrjxz2cDD7fNwkqR4xoi0E/PcfTQGCcdJwLoaxzab5kSadBLj1MTJyT0YRrOXL9umHpXtp+Dv4w==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
@@ -3073,15 +3067,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
+        "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
@@ -4794,22 +4788,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -7555,6 +7533,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -7748,9 +7732,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -8054,14 +8038,6 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-test-renderer/node_modules/scheduler": {
       "version": "0.26.0",
@@ -9433,6 +9409,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-latest-callback": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "expo-status-bar": "~2.2.3",
     "nativewind": "^4.1.23",
     "prettier-plugin-tailwindcss": "^0.5.14",
-    "react": "^19.0.0",
+    "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-css-interop": "^0.1.22",
     "react-native-reanimated": "~3.17.4",
@@ -33,6 +33,9 @@
     "@types/react": "~19.0.10",
     "@types/react-native": "^0.72.8",
     "typescript": "~5.8.3"
+  },
+  "overrides": {
+    "react": "19.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
Dependencies for React 19.0.0 (react-native-renderer, etc.) were clashing with React 19.1.0 so re-installed React and removed '^' from react version in package.json to prevent auto-update to React. Also uninstalled expo-dev-client as this is needed for EAS and was making emulation challenging. We can discuss if we will move forward with EAS if needed.